### PR TITLE
Add notebook smoke tests, QOL changes, part 2

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,13 @@
+[flake8]
+exclude =
+    .git,
+    __pycache__,
+    build,
+    dist,
+    docs/source/conf.py
+max-line-length = 127
+show-source = True
+statistics = True
+count = True
+verbose = 1
+ignore = E203, W503

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -15,11 +15,14 @@ on:
 
 jobs:
   build-linux:
-    runs-on: [ubuntu-latest, osx-latest]
+    
     strategy:
       max-parallel: 5
       matrix:
         python-version: ['3.9', '3.10', '3.11']
+        os: [ubuntu-latest, osx-latest]
+
+    runs-on: ${{ matrix.os }}
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -15,11 +15,11 @@ on:
 
 jobs:
   build-linux:
-    runs-on: ubuntu-latest
+    runs-on: [ubuntu-latest, osx-latest]
     strategy:
       max-parallel: 5
       matrix:
-        python-version: ['3.9', '3.10']
+        python-version: ['3.9', '3.10', '3.11']
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -20,7 +20,7 @@ jobs:
       max-parallel: 5
       matrix:
         python-version: ['3.9', '3.10', '3.11']
-        os: [ubuntu-latest, osx-latest]
+        os: [ubuntu-latest]
 
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/notebook_smoke.yml
+++ b/.github/workflows/notebook_smoke.yml
@@ -47,8 +47,8 @@ jobs:
     - name: Notebook smoke tests
       run: |
         pip install ipython
-	pip install nbformat
-	pip install seaborn
+      	pip install nbformat
+      	pip install seaborn
         cd examples
         ipython -c "%run simpleGP.ipynb"
 

--- a/.github/workflows/notebook_smoke.yml
+++ b/.github/workflows/notebook_smoke.yml
@@ -12,11 +12,14 @@ on:
 
 jobs:
   build-linux:
-    runs-on: [ubuntu-latest, osx-latest]
+    
 
     strategy:
       matrix:
         python-version: ['3.9', '3.10', '3.11']
+        os: [ubuntu-latest, osx-latest]
+
+    runs-on: ${{ matrix.os }}
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/notebook_smoke.yml
+++ b/.github/workflows/notebook_smoke.yml
@@ -1,0 +1,49 @@
+name: notebooks
+  
+on:
+  pull_request:
+    branches:
+      - '*'
+  push:
+    branches:
+      - '*'
+    tags:
+        - '*'
+
+jobs:
+  build-linux:
+    runs-on: [ubuntu-latest, osx-latest]
+
+    strategy:
+      matrix:
+        python-version: ['3.9', '3.10', '3.11']
+
+    steps:
+    - uses: actions/checkout@v2
+      
+    - name: Set up Python ${{ matrix.python-version }}
+      
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: Install dependencies
+      run: |
+        sudo apt-get update -qq
+        python -m pip install --upgrade pip
+        python -m pip install flake8 pytest
+        python -m pip install jaxlib
+        python -m pip install jax
+        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+            
+    - name: install package
+      run: |
+        pip install .
+        pip list
+
+    - name: Notebook smoke tests
+      run: |
+        pip install ipython
+        cd examples
+        ipython -c "%run simpleGP.ipynb"
+

--- a/.github/workflows/notebook_smoke.yml
+++ b/.github/workflows/notebook_smoke.yml
@@ -47,8 +47,8 @@ jobs:
     - name: Notebook smoke tests
       run: |
         pip install ipython
-      	pip install nbformat
-      	pip install seaborn
+        pip install nbformat
+        pip install seaborn
         cd examples
         ipython -c "%run simpleGP.ipynb"
 

--- a/.github/workflows/notebook_smoke.yml
+++ b/.github/workflows/notebook_smoke.yml
@@ -47,6 +47,8 @@ jobs:
     - name: Notebook smoke tests
       run: |
         pip install ipython
+	pip install nbformat
+	pip install seaborn
         cd examples
         ipython -c "%run simpleGP.ipynb"
 

--- a/.github/workflows/notebook_smoke.yml
+++ b/.github/workflows/notebook_smoke.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix:
         python-version: ['3.9', '3.10', '3.11']
-        os: [ubuntu-latest, osx-latest]
+        os: [ubuntu-latest]
 
     runs-on: ${{ matrix.os }}
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,17 @@
+[tool.black]
+line-length = 127
+include = '\.pyi?$'
+exclude = '''
+/(
+  | \.git
+  | \.hg
+  | \.mypy_cache
+  | \.tox
+  | \.venv
+  | _build
+  | buck-out
+  | build
+  | dist
+  | docs/source/conf.py
+)/
+'''


### PR DESCRIPTION
Same as #38 but I actually remembered to pull from upstream first:

Just playing around/exploring the code a bit. While I was I figured I'd make a few QOL changes to the testing system:

- Trying something new by adding a smoke test to the notebook. Figured it could be useful considering the notebooks are hosted on Colab and should always work. It's a fun hack that you can use: `ipython -c "%run simpleGP.ipynb"`, for example.
- Added `osx-latest` to the `runs-on` in the testing jobs. Since the project is open source your CI hours are free so it doesn't matter that it's a more expensive OS to test on.
- Added python version 3.11 to the list of tested versions.
- Added `.flake8` and `pyproject.toml` files for running black (with line length 127). 
- Ran `black` on `gpax.models.gp` as a test (feel free to tell me you don't like this and I'll revert, but stylistically I think it's much easier to read!).

(there will no doubt be bugs which I will fix 👍)