### PR TITLE
MeasuredNoiseGP

### DIFF
--- a/gpax/models/__init__.py
+++ b/gpax/models/__init__.py
@@ -11,6 +11,7 @@ from .vi_mtdkl import viMTDKL
 from .mtgp import MultiTaskGP
 from .corgp import CoregGP
 from .uigp import UIGP
+from .linreg import LinReg
 
 __all__ = [
     "ExactGP",
@@ -25,5 +26,6 @@ __all__ = [
     "viMTDKL",
     "MultiTaskGP",
     "CoregGP",
-    "UIGP"
+    "UIGP",
+    "LinReg"
 ]

--- a/gpax/models/__init__.py
+++ b/gpax/models/__init__.py
@@ -11,6 +11,7 @@ from .vi_mtdkl import viMTDKL
 from .mtgp import MultiTaskGP
 from .corgp import CoregGP
 from .uigp import UIGP
+from .mngp import MeasuredNoiseGP
 from .linreg import LinReg
 
 __all__ = [
@@ -27,5 +28,6 @@ __all__ = [
     "MultiTaskGP",
     "CoregGP",
     "UIGP",
-    "LinReg"
+    "LinReg",
+    "MeasuredNoiseGP"
 ]

--- a/gpax/models/linreg.py
+++ b/gpax/models/linreg.py
@@ -13,7 +13,7 @@ class LinReg:
 
     @staticmethod
     def model(x, y=None):
-        beta = numpyro.sample('beta', dist.Normal(jnp.zeros(x.shape[1]), jnp.ones(x.shape[1])))
+        beta = numpyro.sample('beta', dist.Normal(jnp.zeros(x.shape[1]), 10*jnp.ones(x.shape[1])))
         alpha = numpyro.sample('alpha', dist.Normal(0, 10))
         sigma = numpyro.sample('sigma', dist.HalfCauchy(1))
 

--- a/gpax/models/linreg.py
+++ b/gpax/models/linreg.py
@@ -7,7 +7,7 @@ from numpyro.optim import Adam
 import jax
 
 class LinReg:
-    """Saimple linear regression model"""
+    """Simple linear regression model"""
     def __init__(self):
         self.params = None
 
@@ -37,4 +37,3 @@ class LinReg:
 
     def get_params(self):
         return self.params
-

--- a/gpax/models/linreg.py
+++ b/gpax/models/linreg.py
@@ -1,0 +1,40 @@
+import jax.numpy as jnp
+import numpyro
+import numpyro.distributions as dist
+from numpyro.infer import SVI, Trace_ELBO
+from numpyro.infer.autoguide import AutoDiagonalNormal
+from numpyro.optim import Adam
+import jax
+
+class LinReg:
+    """Saimple linear regression model"""
+    def __init__(self):
+        self.params = None
+
+    @staticmethod
+    def model(x, y=None):
+        beta = numpyro.sample('beta', dist.Normal(jnp.zeros(x.shape[1]), jnp.ones(x.shape[1])))
+        alpha = numpyro.sample('alpha', dist.Normal(0, 10))
+        sigma = numpyro.sample('sigma', dist.HalfCauchy(1))
+
+        mu = alpha + jnp.dot(x, beta)
+        with numpyro.plate('data', x.shape[0]):
+            numpyro.sample('obs', dist.Normal(mu, sigma), obs=y)
+
+    def train(self, x, y, learning_rate=0.01, num_iterations=5000):
+        guide = AutoDiagonalNormal(self.model)
+        optimizer = Adam(step_size=learning_rate)
+        svi = SVI(self.model, guide, optimizer, loss=Trace_ELBO(), x=x, y=y)
+
+        params, _, _ = svi.run(jax.random.PRNGKey(0), num_iterations, progress_bar=False)
+        self.params = svi.guide.median(params)
+
+    def predict(self, x_new):
+        alpha = self.params['alpha']
+        beta = self.params['beta']
+        sigma = self.params['sigma']
+        return alpha + jnp.dot(x_new, beta)
+
+    def get_params(self):
+        return self.params
+

--- a/gpax/models/mngp.py
+++ b/gpax/models/mngp.py
@@ -127,7 +127,8 @@ class MeasuredNoiseGP(ExactGP):
         # Add predicted noise to K's diagonal
         K += jnp.diag(noise_predicted)
         # Draw samples from the posterior predictive for a given set of parameters
-        y_sampled = dist.MultivariateNormal(y_mean, K).sample(rng_key, sample_shape=(n,))
+        sig = jnp.sqrt(jnp.clip(jnp.diag(K), a_min=0.0)) * jax.random.normal(rng_key, X_new.shape[:1])
+        y_sampled = jnp.expand_dims(y_mean + sig)
         return y_mean, y_sampled
     
     def predict(

--- a/gpax/models/mngp.py
+++ b/gpax/models/mngp.py
@@ -38,7 +38,7 @@ class MeasuredNoiseGP(ExactGP):
         else:
             kernel_params = self._sample_kernel_params()
         # Since we provide a measured noise, we don't infer it
-        noise = numpyro.deterministic("noise", jnp.ndarray(0.0))
+        noise = numpyro.deterministic("noise", jnp.array(0.0))
         # Add mean function (if any)
         if self.mean_fn is not None:
             args = [X]

--- a/gpax/models/mngp.py
+++ b/gpax/models/mngp.py
@@ -12,6 +12,7 @@ from numpyro.infer import MCMC, NUTS, init_to_median
 from .gp import ExactGP
 from .vigp import viGP
 from .linreg import LinReg
+from ..utils import get_keys
 
 kernel_fn_type = Callable[[jnp.ndarray, jnp.ndarray, Dict[str, jnp.ndarray], jnp.ndarray], jnp.ndarray]
 
@@ -204,7 +205,8 @@ class MeasuredNoiseGP(ExactGP):
         lreg.train(x, y, **kwargs)
         return lreg.predict(x_new)
     
-    def gpreg(self, rng_key, x, y, x_new, **kwargs):
+    def gpreg(self, x, y, x_new, **kwargs):
+        keys = get_keys()
         vigp = viGP(self.kernel_dim, 'RBF', **kwargs)
-        vigp.fit(rng_key, x, y, **kwargs)
-        return vigp.predict(rng_key, x_new, noiseless=True)
+        vigp.fit(keys[0], x, y, **kwargs)
+        return vigp.predict(keys[1], x_new, noiseless=True)

--- a/gpax/models/mngp.py
+++ b/gpax/models/mngp.py
@@ -208,5 +208,5 @@ class MeasuredNoiseGP(ExactGP):
     def gpreg(self, x, y, x_new, **kwargs):
         keys = get_keys()
         vigp = viGP(self.kernel_dim, 'RBF', **kwargs)
-        vigp.fit(keys[0], x, y, **kwargs)
-        return vigp.predict(keys[1], x_new, noiseless=True)
+        vigp.fit(keys[0], x, y, progress_bar=False, print_summary=False, **kwargs)
+        return vigp.predict(keys[1], x_new, noiseless=True)[0]

--- a/gpax/models/mngp.py
+++ b/gpax/models/mngp.py
@@ -128,7 +128,7 @@ class MeasuredNoiseGP(ExactGP):
         K += jnp.diag(noise_predicted)
         # Draw samples from the posterior predictive for a given set of parameters
         sig = jnp.sqrt(jnp.clip(jnp.diag(K), a_min=0.0)) * jax.random.normal(rng_key, X_new.shape[:1])
-        y_sampled = jnp.expand_dims(y_mean + sig)
+        y_sampled = jnp.expand_dims(y_mean + sig, 0)
         return y_mean, y_sampled
     
     def predict(

--- a/gpax/models/mngp.py
+++ b/gpax/models/mngp.py
@@ -171,7 +171,7 @@ class MeasuredNoiseGP(ExactGP):
             noise_predicted = self.noise_predicted
         else:
             noise_predicted = self.linreg(self.X_train, self.measured_noise, X_new)
-
+            self.noise_predicted = noise_predicted
         if samples is None:
             samples = self.get_samples(chain_dim=False)
         if device:

--- a/gpax/models/mngp.py
+++ b/gpax/models/mngp.py
@@ -29,7 +29,7 @@ class MeasuredNoiseGP(ExactGP):
         self.measured_noise = None
         self.noise_predicted = None
 
-    def model(self, X: jnp.ndarray, measured_noise: jnp.ndarray, y: jnp.ndarray = None, **kwargs) -> None:
+    def model(self, X: jnp.ndarray, y: jnp.ndarray = None, measured_noise: jnp.ndarray = None, **kwargs) -> None:
         # Initialize mean function at zeros
         f_loc = jnp.zeros(X.shape[0])
         # Sample kernel parameters
@@ -108,7 +108,7 @@ class MeasuredNoiseGP(ExactGP):
             progress_bar=progress_bar,
             jit_model_args=False,
         )
-        self.mcmc.run(rng_key, X, y, **kwargs)
+        self.mcmc.run(rng_key, X, y, measured_noise, **kwargs)
         if print_summary:
             self._print_summary()
 

--- a/gpax/models/mngp.py
+++ b/gpax/models/mngp.py
@@ -1,0 +1,193 @@
+from typing import Callable, Dict, Optional, Tuple, Type, Union
+
+import jax
+import jaxlib
+import jax.numpy as jnp
+import jax.random as jra
+import numpyro
+import numpyro.distributions as dist
+from numpyro.infer import MCMC, NUTS, init_to_median
+
+
+from .gp import ExactGP
+from .linreg import LinReg
+
+kernel_fn_type = Callable[[jnp.ndarray, jnp.ndarray, Dict[str, jnp.ndarray], jnp.ndarray], jnp.ndarray]
+
+
+class MeasuredNoiseGP(ExactGP):
+    def __init__(self,
+                 input_dim: int,
+                 kernel: Union[str, kernel_fn_type],
+                 mean_fn: Optional[Callable[[jnp.ndarray, Dict[str, jnp.ndarray]], jnp.ndarray]] = None,
+                 kernel_prior: Optional[Callable[[], Dict[str, jnp.ndarray]]] = None,
+                 mean_fn_prior: Optional[Callable[[], Dict[str, jnp.ndarray]]] = None,
+                 lengthscale_prior_dist: Optional[dist.Distribution] = None) -> None:
+        
+        args = (input_dim, kernel, mean_fn, kernel_prior, mean_fn_prior, None, None, lengthscale_prior_dist)
+        super(MeasuredNoiseGP, self).__init__(*args)
+        self.measured_noise = None
+        self.noise_predicted = None
+
+    def model(self, X: jnp.ndarray, measured_noise: jnp.ndarray, y: jnp.ndarray = None, **kwargs) -> None:
+        # Initialize mean function at zeros
+        f_loc = jnp.zeros(X.shape[0])
+        # Sample kernel parameters
+        if self.kernel_prior:
+            kernel_params = self.kernel_prior()
+        else:
+            kernel_params = self._sample_kernel_params()
+        # Since we provide a measured noise, we don't infer it
+        noise = numpyro.deterministic("noise", jnp.ndarray(0.0))
+        # Add mean function (if any)
+        if self.mean_fn is not None:
+            args = [X]
+            if self.mean_fn_prior is not None:
+                args += [self.mean_fn_prior()]
+            f_loc += self.mean_fn(*args).squeeze()
+        # compute kernel (with zero noise)
+        k = self.kernel(X, X, kernel_params, 0, **kwargs)
+        # Sample y according to the standard Gaussian process formula. Add measured noise to the covariance matrix
+        numpyro.sample(
+            "y",
+            dist.MultivariateNormal(loc=f_loc, covariance_matrix=k+jnp.diag(measured_noise)),
+            obs=y,
+        )
+
+    def fit(
+        self,
+        rng_key: jnp.array,
+        X: jnp.ndarray,
+        y: jnp.ndarray,
+        measured_noise: jnp.ndarray,
+        num_warmup: int = 2000,
+        num_samples: int = 2000,
+        num_chains: int = 1,
+        chain_method: str = "sequential",
+        progress_bar: bool = True,
+        print_summary: bool = True,
+        device: Type[jaxlib.xla_extension.Device] = None,
+        **kwargs: float
+    ) -> None:
+        """
+        Run Hamiltonian Monter Carlo to infer the GP parameters
+
+        Args:
+            rng_key: random number generator key
+            X: 2D feature vector
+            y: 1D target vector
+            num_warmup: number of HMC warmup states
+            num_samples: number of HMC samples
+            num_chains: number of HMC chains
+            chain_method: 'sequential', 'parallel' or 'vectorized'
+            progress_bar: show progress bar
+            print_summary: print summary at the end of sampling
+            device:
+                optionally specify a cpu or gpu device on which to run the inference;
+                e.g., ``device=jax.devices("cpu")[0]``
+            **jitter:
+                Small positive term added to the diagonal part of a covariance
+                matrix for numerical stability (Default: 1e-6)
+        """
+        X, y = self._set_data(X, y)
+        if device:
+            X = jax.device_put(X, device)
+            y = jax.device_put(y, device)
+        self.X_train = X
+        self.y_train = y
+        self.measured_noise = measured_noise
+
+        init_strategy = init_to_median(num_samples=10)
+        kernel = NUTS(self.model, init_strategy=init_strategy)
+        self.mcmc = MCMC(
+            kernel,
+            num_warmup=num_warmup,
+            num_samples=num_samples,
+            num_chains=num_chains,
+            chain_method=chain_method,
+            progress_bar=progress_bar,
+            jit_model_args=False,
+        )
+        self.mcmc.run(rng_key, X, y, **kwargs)
+        if print_summary:
+            self._print_summary()
+
+    def _predict(
+        self,
+        rng_key: jnp.ndarray,
+        X_new: jnp.ndarray,
+        params: Dict[str, jnp.ndarray],
+        noise_predicted: jnp.ndarray,
+        n: int,
+        noiseless: bool = False,
+        **kwargs: float) -> Tuple[jnp.ndarray, jnp.ndarray]:
+        """Prediction with a single sample of GP parameters"""
+        # Get the predictive mean and covariance
+        y_mean, K = self.get_mvn_posterior(X_new, params, noiseless, **kwargs)
+        # Add predicted noise to K's diagonal
+        K += jnp.diag(noise_predicted)
+        # Draw samples from the posterior predictive for a given set of parameters
+        y_sampled = dist.MultivariateNormal(y_mean, K).sample(rng_key, sample_shape=(n,))
+        return y_mean, y_sampled
+    
+    def predict(
+        self,
+        rng_key: jnp.ndarray,
+        X_new: jnp.ndarray,
+        samples: Optional[Dict[str, jnp.ndarray]] = None,
+        n: int = 1,
+        filter_nans: bool = False,
+        noiseless: bool = False,
+        device: Type[jaxlib.xla_extension.Device] = None,
+        **kwargs: float
+    ) -> Tuple[jnp.ndarray, jnp.ndarray]:
+        """
+        Make prediction at X_new points using posterior samples for GP parameters
+
+        Args:
+            rng_key: random number generator key
+            X_new: new inputs with *(number of points, number of features)* dimensions
+            samples: optional (different) samples with GP parameters
+            n: number of samples from Multivariate Normal posterior for each HMC sample with GP parameters
+            filter_nans: filter out samples containing NaN values (if any)
+            noiseless:
+                Noise-free prediction. It is set to False by default as new/unseen data is assumed
+                to follow the same distribution as the training data. Hence, since we introduce a model noise
+                by default for the training data, we also want to include that noise in our prediction.
+            device:
+                optionally specify a cpu or gpu device on which to make a prediction;
+                e.g., ```device=jax.devices("gpu")[0]```
+            **jitter:
+                Small positive term added to the diagonal part of a covariance
+                matrix for numerical stability (Default: 1e-6)
+
+        Returns
+            Center of the mass of sampled means and all the sampled predictions
+        """
+        X_new = self._set_data(X_new)
+
+        # Predict noise for X_new
+        if self.noise_predicted is not None:
+            noise_predicted = self.noise_predicted
+        else:
+            noise_predicted = self.linreg(self.X_train, self.measured_noise, X_new)
+
+        if samples is None:
+            samples = self.get_samples(chain_dim=False)
+        if device:
+            self._set_training_data(device=device)
+            X_new = jax.device_put(X_new, device)
+            samples = jax.device_put(samples, device)
+        num_samples = len(next(iter(samples.values())))
+        vmap_args = (jra.split(rng_key, num_samples), samples)
+        predictive = jax.vmap(lambda prms: self._predict(prms[0], X_new, prms[1], noise_predicted, n, noiseless, **kwargs))
+        y_means, y_sampled = predictive(vmap_args)
+        if filter_nans:
+            y_sampled_ = [y_i for y_i in y_sampled if not jnp.isnan(y_i).any()]
+            y_sampled = jnp.array(y_sampled_)
+        return y_means.mean(0), y_sampled
+    
+    def linreg(self, x, y, x_new, **kwargs):
+        lreg = LinReg()
+        lreg.train(x, y, **kwargs)
+        return lreg.predict(x_new)

--- a/tests/test_mngp.py
+++ b/tests/test_mngp.py
@@ -1,0 +1,97 @@
+import sys
+import pytest
+import numpy as onp
+import jax.numpy as jnp
+import jax
+import numpyro
+import numpyro.distributions as dist
+from numpy.testing import assert_equal, assert_array_equal, assert_
+
+sys.path.insert(0, "../gpax/")
+
+from gpax.models.mngp import MeasuredNoiseGP
+from gpax.utils import get_keys
+
+
+def variable_noise(x):
+    return 0.1 + 0.5 * x
+
+def get_dummy_data():
+    f = lambda x: onp.sin(x) * x
+    X = onp.linspace(1, 2, 8)
+    y_all = onp.array([f(x) + onp.random.normal(0, variable_noise(x), 10) for x in X])
+    y = y_all.mean(1)
+    measured_noise = y_all.var(1)
+    return jnp.array(X), jnp.array(y), jnp.array(measured_noise)
+
+
+def test_fit():
+    rng_key = get_keys()[0]
+    X, y, measured_noise = get_dummy_data()
+    m = MeasuredNoiseGP(1, 'RBF')
+    m.fit(rng_key, X, y, measured_noise, num_warmup=10, num_samples=10)
+    assert m.mcmc is not None
+
+
+def test_get_mvn_posterior():
+    X, y, measured_noise = get_dummy_data()
+    X_test, _, _ = get_dummy_data()
+    X = X[:, None]
+    X_test = X_test[:, None]
+    params = {"k_length": jnp.array([1.0]),
+              "k_scale": jnp.array(1.0),
+              "noise": jnp.array(0.0),
+              }
+    m = MeasuredNoiseGP(1, 'RBF')
+    m.X_train = X
+    m.y_train = y
+    m.measured_noise = measured_noise
+    mean, cov = m.get_mvn_posterior(X_test, params)
+    assert isinstance(mean, jnp.ndarray)
+    assert isinstance(cov, jnp.ndarray)
+    assert_equal(mean.shape, (X_test.shape[0],))
+    assert_equal(cov.shape, (X_test.shape[0], X_test.shape[0]))
+
+
+@pytest.mark.parametrize("n", [1, 5])
+def test_predict_single_sample(n):
+    key = get_keys()[0]
+    X, y, measured_noise = get_dummy_data()
+    X_test, _, _ = get_dummy_data()
+    X = X[:, None]
+    X_test = X_test[:, None]
+    params = {"k_length": jnp.array([1.0]),
+              "k_scale": jnp.array(1.0),
+              "noise": jnp.array(0.0),
+              }
+    m = MeasuredNoiseGP(1, 'RBF')
+    m.X_train = X
+    m.y_train = y
+    m.measured_noise = measured_noise
+    noise_predicted = 0.5 * X_test
+    mean, sample = m._predict(key, X_test, params, noise_predicted, n)
+    assert isinstance(mean, jnp.ndarray)
+    assert isinstance(sample, jnp.ndarray)
+    assert_equal(mean.shape, (X_test.shape[0],))
+    assert_equal(sample.shape, (n, X_test.shape[0]))
+ 
+
+@pytest.mark.parametrize("noise_pred_fn", ['linreg', 'gpreg'])
+def test_predict(noise_pred_fn):
+    rng_keys = get_keys()
+    X, y, measured_noise = get_dummy_data()
+    X = X[:, None]
+    X_test, _, _ = get_dummy_data()
+    samples = {"k_length": jax.random.normal(rng_keys[0], shape=(100, 1)),
+               "k_scale": jax.random.normal(rng_keys[0], shape=(100,)),
+               "noise": jax.random.normal(rng_keys[0], shape=(100,))}
+    m = MeasuredNoiseGP(1, 'RBF')
+    m.X_train = X
+    m.y_train = y
+    m.measured_noise = measured_noise
+    y_mean, y_sampled = m.predict(rng_keys[1], X_test, samples, noise_prediction_method=noise_pred_fn)
+    assert isinstance(y_mean, jnp.ndarray)
+    assert isinstance(y_sampled, jnp.ndarray)
+    assert_equal(y_mean.shape, (X_test.shape[0],))
+    assert_equal(y_sampled.shape, (100, 1, X_test.shape[0]))
+    

--- a/tests/test_uigp.py
+++ b/tests/test_uigp.py
@@ -59,7 +59,7 @@ def test_get_mvn_posterior():
 
 
 @pytest.mark.parametrize("noiseless", [True, False])
-def test_predict(noiseless):
+def test_predict_single_sample(noiseless):
     key = get_keys()[0]
     X, y = get_dummy_data()
     X_test, _ = get_dummy_data()
@@ -68,11 +68,14 @@ def test_predict(noiseless):
     params = {"k_length": jnp.array([1.0]),
               "k_scale": jnp.array(1.0),
               "noise": jnp.array(0.1),
-              "k_noise_length": jnp.array(0.5),
               "sigma_x": jnp.array(0.3),
               "X_prime": jnp.array(X + 0.1)
               }
     m = UIGP(1, 'RBF')
     m.X_train = X
     m.y_train = y
-    m._predict(key, X_test, params, 5, noiseless)
+    mean, sample = m._predict(key, X_test, params, 5, noiseless)
+    assert isinstance(mean, jnp.ndarray)
+    assert isinstance(sample, jnp.ndarray)
+    assert_equal(mean.shape, (X_test.shape[0],))
+    assert_equal(sample.shape, (5, X_test.shape[0]))


### PR DESCRIPTION
This class extends the ExactGP model by allowing the inclusion of measured noise variances in the GP framework. Unlike standard GP models, where noise is typically inferred, this model uses noise values obtained from repeated measurements at the same input points.

cc: @SergeiVKalinin  @arpanbiswas52
